### PR TITLE
Preserve threadId on QueryEvent

### DIFF
--- a/src/zalora/binlog-parser/parser/conversion/conversion.go
+++ b/src/zalora/binlog-parser/parser/conversion/conversion.go
@@ -34,6 +34,7 @@ func ConvertQueryEventToMessage(binlogEventHeader replication.EventHeader, binlo
 	message := messages.NewQueryMessage(
 		header,
 		messages.SqlQuery(binlogEvent.Query),
+		binlogEvent.SlaveProxyID,
 	)
 
 	return messages.Message(message)

--- a/src/zalora/binlog-parser/parser/messages/message.go
+++ b/src/zalora/binlog-parser/parser/messages/message.go
@@ -60,11 +60,12 @@ type SqlQuery string
 
 type QueryMessage struct {
 	baseMessage
-	Query SqlQuery
+	Query    SqlQuery
+	ThreadId uint32
 }
 
-func NewQueryMessage(header MessageHeader, query SqlQuery) QueryMessage {
-	return QueryMessage{baseMessage: baseMessage{Header: header, Type: MESSAGE_TYPE_QUERY}, Query: query}
+func NewQueryMessage(header MessageHeader, query SqlQuery, threadId uint32) QueryMessage {
+	return QueryMessage{baseMessage: baseMessage{Header: header, Type: MESSAGE_TYPE_QUERY}, Query: query, ThreadId: threadId}
 }
 
 type UpdateMessage struct {


### PR DESCRIPTION
I added `ThreadId` to QueryEvent. It may help debug database changes by linking a statement/row change to a particular connection.